### PR TITLE
Provide a more stable raw mirror server

### DIFF
--- a/common/lx_script.py
+++ b/common/lx_script.py
@@ -28,7 +28,7 @@ async def get_response(retry = 0):
             # req = await Httpx.AsyncRequest('https://mirror.ghproxy.com/' + baseurl)
             # `mirror.ghproxy.com` server is unstable to access in China,
             # Here provided a self built mirror site of `raw.githubusercontent.com`.
-            # It's drove by Vercel, and please use it low-key,
+            # It's drive by Vercel, and please use it low-key,
             # (It's the only one domain name I hold, I don't wish it been blocked by GFW)
             req = await Httpx.AsyncRequest(baseurl.replace('raw.githubusercontent.com', 'ghraw.gkcoll.xyz'))
         else:

--- a/common/lx_script.py
+++ b/common/lx_script.py
@@ -25,7 +25,12 @@ async def get_response(retry = 0):
     baseurl = 'https://raw.githubusercontent.com/lxmusics/lx-music-api-server/main/lx-music-source-example.js'
     try:
         if (iscn and (retry % 2) == 0):
-            req = await Httpx.AsyncRequest('https://mirror.ghproxy.com/' + baseurl)
+            # req = await Httpx.AsyncRequest('https://mirror.ghproxy.com/' + baseurl)
+            # `mirror.ghproxy.com` server is unstable to access in China,
+            # Here provided a self built mirror site of `raw.githubusercontent.com`.
+            # It's drove by Vercel, and please use it low-key,
+            # (It's the only one domain name I hold, I don't wish it been blocked by GFW)
+            req = await Httpx.AsyncRequest(baseurl.replace('raw.githubusercontent.com', 'ghraw.gkcoll.xyz'))
         else:
             req = await Httpx.AsyncRequest(baseurl)
     except Exception as e:


### PR DESCRIPTION
mirror.ghproxy.com is now unstable to access in China (Environment: China Telecom, Guangdong). 

Coincidentally, I set up a service of github raw link proxy just few days ago. For me, it's not commonly used. But I hope it can add luster to this project.

Domain is included in code file, please DON'T ABUSE IT.