### PR TITLE
修复网易云flac24bit下载和波点获取音乐问题uid

### DIFF
--- a/modules/kw/__init__.py
+++ b/modules/kw/__init__.py
@@ -42,7 +42,7 @@ async def url(songId, quality):
     proto = config.read_config('module.kw.proto')
     if (proto == 'bd-api'):
         user_info = config.read_config('module.kw.user') if (not variable.use_cookie_pool) else random.choice(config.read_config('module.cookiepool.kw'))
-        target_url = f'''https://bd-api.kuwo.cn/api/service/music/downloadInfo/{songId}?isMv=0&format={tools['extMap'][quality]}&br={tools['qualityMap'][quality]}&uin={user_info['uid']}&token={user_info['token']}'''
+        target_url = f'''https://bd-api.kuwo.cn/api/service/music/downloadInfo/{songId}?isMv=0&format={tools['extMap'][quality]}&br={tools['qualityMap'][quality]}&uid={user_info['uid']}&token={user_info['token']}'''
         req = await Httpx.AsyncRequest(target_url, {
             'method': 'GET',
             'headers': {

--- a/modules/wy/__init__.py
+++ b/modules/wy/__init__.py
@@ -20,7 +20,7 @@ tools = {
         "192k": "higher",
         '320k': 'exhigh',
         'flac': 'lossless',
-        'flac24bit': 'hires',
+        'flac24bit': 'lossless',
         "dolby": "jyeffect",
         "sky": "sky",
         "master": "jymaster",


### PR DESCRIPTION
flac24bit和flac的接口返回都是lossless